### PR TITLE
Fix date() warning

### DIFF
--- a/view/frontend/templates/expecteddelivery/product.phtml
+++ b/view/frontend/templates/expecteddelivery/product.phtml
@@ -8,7 +8,7 @@ if ($isEnabled) {
     $canSendToday = $block->getMaxTimeToday() && $block->getMaxTimeToday() < time();
 
     //display one of these <p>. If $canSendToday returns true, display the first one. If $canSendToday returns false, return the second one.
-    ?><p style="display:none"><?= /* @noEscape */ sprintf(__('You can get this product on %s (%s) if you buy it now!'), date('d.m.Y', $block->getShipDayName()), $block->getShipDayTime()); ?></p><?php
-?><p style="display:none"><?= /* @noEscape */ sprintf(__('You can get this product on %s (%s) if you buy it now!'), date('d.m.Y', $block->getNextShipDayName()), $block->getNextShipDayTime()); ?></p><?php
+    ?><p style="display:none"><?= /* @noEscape */ sprintf(__('You can get this product on %s (%s) if you buy it now!'), $block->getShipDayName(), $block->getShipDayTime()); ?></p><?php
+    ?><p style="display:none"><?= /* @noEscape */ sprintf(__('You can get this product on %s (%s) if you buy it now!'), $block->getNextShipDayName(), $block->getNextShipDayTime()); ?></p><?php
 }
 ?>


### PR DESCRIPTION
This fixes the following warning:

```
Exception #0 (Exception): Warning: date() expects parameter 2 to be int, string given in vendor/creativestyle/magesuite-product-positive-indicators/view/frontend/templates/expecteddelivery/product.phtml on line 11
```

I am not sure what the original intention here was though. `$block->getShipDayName()` already returns a translated weekday name (like "Montag" in German). The `date()` function needs a UNIX timestamp for the second parameter. This PR simply removes the usage of date, so that the message says

```
You can get this product on Monday (12:00) if you buy it now!
```